### PR TITLE
Adds functionality to generate scan report in JSON format (#104)

### DIFF
--- a/.talismanrc
+++ b/.talismanrc
@@ -2,3 +2,6 @@ fileignoreconfig:
 - filename    : private.pem
   checksum    : 
   ignore_detectors : [filename,filecontent]
+- filename: detector/pattern_detector.go
+  checksum: 1c46863e979796d929522d73c465643b8794cccbf0054cb1ca6903a143e54757
+  ignore_detectors: []

--- a/README.md
+++ b/README.md
@@ -310,6 +310,16 @@ To run the scanner please "cd" into the directory to be scanned and run the foll
 
 * `talisman --scan`
 
+Running this command will create a folder named <i>talisman_reports</i> in the root of the current directory and store the report files there.
+
+In case you want to store the reports in some other location, it can be provided as an option with the command:
+
+* `talisman --scan --reportdirectory=/Users/username/Desktop`
+
+   OR
+
+* `talisman --scan --rd=/Users/username/Desktop`
+
 <i>Talisman currently does not support ignoring of files for scanning.</i>
 
 # Uninstallation

--- a/detector/filecontent_detector.go
+++ b/detector/filecontent_detector.go
@@ -66,7 +66,7 @@ func fillResults(results []string, addition git_repo.Addition, result *Detection
 				"filePath": addition.Path,
 			}).Info(info)
 			if string(addition.Name) == DefaultRCFileName {
-				result.Warn(addition.Path, fmt.Sprintf(output, res))
+				result.Warn(addition.Path, fmt.Sprintf(output, res), []string{})
 			} else {
 				result.Fail(addition.Path, fmt.Sprintf(output, res), []string{})
 			}

--- a/detector/json_detection_results.go
+++ b/detector/json_detection_results.go
@@ -1,0 +1,72 @@
+package detector
+
+import "talisman/git_repo"
+
+type Details struct {
+	Category string `json:"type"`
+	Message string `json:"message"`
+	Commits []string `json:"commits"`
+}
+
+type ResultsDetails struct {
+	Filename git_repo.FilePath `json:"filename"`
+	FailureList []Details      `json:"failure_list"`
+	WarningList []Details      `json:"warning_list"`
+}
+
+type FailureTypes struct  {
+	Filecontent int `json:"filecontent"`
+	Filesize int `json:"filesize"`
+	Filename int `json:"filename"`
+}
+
+type ResultsSummary struct {
+	Types FailureTypes `json:"types"`
+}
+
+type JsonDetectionResults struct {
+	Summary ResultsSummary `json:"summary"`
+	Results []ResultsDetails `json:"results"`
+
+}
+
+func (result JsonDetectionResults) getResultObjectForFileName(filename git_repo.FilePath) ResultsDetails {
+	for _, resultDetails := range result.Results {
+		if resultDetails.Filename == filename {
+			return resultDetails
+		}
+	}
+	return ResultsDetails{"", make([]Details, 0), make([]Details, 0)}
+}
+
+func GetJsonSchema(r *DetectionResults) JsonDetectionResults {
+
+	jsonResults := JsonDetectionResults{}
+	failures := r.Failures
+	for path, data := range failures {
+		resultDetails := ResultsDetails{}
+		resultDetails.Filename = path
+
+		for message, commits := range data.FailuresInCommits {
+			failureDetails := Details{}
+			failureDetails.Message = message
+			failureDetails.Commits = commits
+			resultDetails.FailureList = append(resultDetails.FailureList, failureDetails)
+		}
+		jsonResults.Results = append(jsonResults.Results, resultDetails)
+	}
+	warnings := r.warnings
+	for path, data := range warnings {
+		resultDetails := jsonResults.getResultObjectForFileName(path)
+		resultDetails.Filename = path
+
+		for message, commits := range data.FailuresInCommits {
+			failureDetails := Details{}
+			failureDetails.Message = message
+			failureDetails.Commits = commits
+			resultDetails.WarningList = append(resultDetails.WarningList, failureDetails)
+		}
+	}
+	return jsonResults
+}
+

--- a/detector/pattern_detector.go
+++ b/detector/pattern_detector.go
@@ -29,7 +29,7 @@ func (detector PatternDetector) Test(additions []git_repo.Addition, ignoreConfig
 						"filePath": addition.Path,
 						"pattern":  detection,
 					}).Warn("Warning file as it matched pattern.")
-					result.Warn(addition.Path, fmt.Sprintf("Potential secret pattern : %s", detection))
+					result.Warn(addition.Path, fmt.Sprintf("Potential secret pattern : %s", detection), addition.Commits)
 				} else {
 					log.WithFields(log.Fields{
 						"filePath": addition.Path,

--- a/runner.go
+++ b/runner.go
@@ -37,13 +37,14 @@ func (r *Runner) RunWithoutErrors() int {
 }
 
 //Scan scans git commit history for potential secrets and returns 0 or 1 as exit code
-func (r *Runner) Scan() int {
+func (r *Runner) Scan(reportDirectory string) int {
+
 	fmt.Println("Please wait while talisman scans entire repository including the git history...")
 	additions := scanner.GetAdditions()
 	ignores := detector.TalismanRCIgnore{}
 	detector.DefaultChain().Test(additions, ignores, r.results)
-	report.GenerateReport(r.results)
-	fmt.Println("Please check report.html in your current directory for the talisman scan report")
+	reportsPath := report.GenerateReport(r.results, reportDirectory)
+	fmt.Printf("Please check %s folder for the talisman scan report", reportsPath)
 	return r.exitStatus()
 }
 

--- a/talisman.go
+++ b/talisman.go
@@ -22,6 +22,7 @@ var (
 	Version  = "Development Build"
 	scan     bool
 	checksum string
+	reportdirectory string
 )
 
 const (
@@ -41,6 +42,7 @@ type options struct {
 	pattern  string
 	scan     bool
 	checksum string
+	reportdirectory string
 }
 
 //Logger is the default log device, set to emit at the Error level by default
@@ -56,6 +58,8 @@ func main() {
 	flag.BoolVar(&scan, "scan", false, "scanner scans the git commit history for potential secrets")
 	flag.StringVar(&checksum, "c", "", "short form of checksum calculator")
 	flag.StringVar(&checksum, "checksum", "", "checksum calculator calculates checksum and suggests .talsimarc format")
+	flag.StringVar(&reportdirectory, "reportdirectory", "", "directory where the scan reports will be stored")
+	flag.StringVar(&reportdirectory, "rd", "", "short form of report directory")
 
 	flag.Parse()
 
@@ -75,6 +79,7 @@ func main() {
 		pattern:  pattern,
 		scan:     scan,
 		checksum: checksum,
+		reportdirectory: reportdirectory,
 	}
 
 	os.Exit(run(os.Stdin, _options))
@@ -97,7 +102,7 @@ func run(stdin io.Reader, _options options) (returnCode int) {
 		return NewRunner(make([]git_repo.Addition, 0)).RunChecksumCalculator(strings.Fields(_options.checksum))
 	} else if _options.scan {
 		log.Infof("Running scanner")
-		return NewRunner(make([]git_repo.Addition, 0)).Scan()
+		return NewRunner(make([]git_repo.Addition, 0)).Scan(_options.reportdirectory)
 	} else if _options.pattern != "" {
 		log.Infof("Running %s pattern", _options.pattern)
 		directoryHook := NewDirectoryHook()


### PR DESCRIPTION
- Generate scan report in JSON format, to be stored in report.json, and HTML format in report.html
- User can specify the directory where the reports will be stored
- Made changes to report failures in .talismanrc as 'Warnings'